### PR TITLE
Correcting names

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2023 East Genomics
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,4 @@
-<!-- dx-header -->
-# VCF Header Corrector (DNAnexus Platform App)
+# eggd vcf header corrector (DNAnexus Platform App)
 
 ## What does this app do?
 This app adds a sample's ID number to the headers of compressed Mutect2 and cgpPindel VCF files, generating a new file for each.

--- a/dxapp.json
+++ b/dxapp.json
@@ -3,7 +3,7 @@
   "title": "eggd_vcf_header_corrector",
   "summary": "Adjusts the headers of VCF files produced by Mutect2 and cgpPindel.",
   "dxapi": "1.0.0",
-  "version": "1.0.0",
+  "version":"1.0.1",
   "inputSpec": [
     {
       "name": "mutect2_input",

--- a/dxapp.json
+++ b/dxapp.json
@@ -1,7 +1,7 @@
 {
-  "name": "vcf_header_corrector",
-  "title": "VCF Header Corrector",
-  "summary": "Adjusts the headers of VCF files produced by Mutect2 and cpgPindel.",
+  "name": "eggd_vcf_header_corrector",
+  "title": "eggd_vcf_header_corrector",
+  "summary": "Adjusts the headers of VCF files produced by Mutect2 and cgpPindel.",
   "dxapi": "1.0.0",
   "version": "1.0.0",
   "inputSpec": [


### PR DESCRIPTION
Changes made:
- Incremented version to 1.0.1
- Fixed a typo in cpgPinder
- Prepended eggd_ to name of app
- Added an MIT license doc

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/eastgenomics/eggd_vcf_header_corrector/2)
<!-- Reviewable:end -->
